### PR TITLE
fix: update JitPack to use JDK 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,2 @@
-before_install:
-  - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
-  - source install-jdk.sh --feature 17
+jdk:
+  - openjdk21


### PR DESCRIPTION
Fabric Loom 1.14+ requires JDK 21 (see error: "Dependency requires at least JVM runtime version 21").
The current `jitpack.yml` installs JDK 17 via the sormuras script, which causes JitPack builds to fail

Replaces the outdated sormuras installer with JitPack's native `openjdk21` support, which has
been available on JitPack for a while and doesn't need a third-party install script